### PR TITLE
feature: init get block info by given id

### DIFF
--- a/src/handler/handler_v1_impl.go
+++ b/src/handler/handler_v1_impl.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/afunTW/eth-data-provider/src/config"
@@ -27,6 +29,7 @@ func (h *handlerV1Impl) GetLatestBlocks(ctx *gin.Context) {
 		})
 		return
 	}
+	// TODO: get latest N blocks
 	ctx.JSON(http.StatusOK, RespGetLatestBlocks{
 		Blocks: []BlockInfo{},
 		RespStatus: RespStatus{
@@ -36,5 +39,27 @@ func (h *handlerV1Impl) GetLatestBlocks(ctx *gin.Context) {
 	})
 }
 
-func (h *handlerV1Impl) GetBlockById(ctx *gin.Context)           {}
+func (h *handlerV1Impl) GetBlockById(ctx *gin.Context) {
+	argBlockId := ctx.Param("id")
+	blockId, err := strconv.Atoi(argBlockId)
+	if err != nil {
+		log.Error(err)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, RespStatus{
+			Message:   fmt.Sprintf("Failed to get the block id %v", argBlockId),
+			Timestamp: uint64(time.Now().UnixNano()),
+		})
+		return
+	}
+	// TODO: get block info by given block id
+	log.Debugf("Get blockId %v\n", blockId)
+	ctx.JSON(http.StatusOK, RespGetBlockDetail{
+		BlockInfo:    BlockInfo{},
+		Transactions: []string{},
+		RespStatus: RespStatus{
+			Message:   "Success",
+			Timestamp: uint64(time.Now().UnixNano()),
+		},
+	})
+}
+
 func (h *handlerV1Impl) GetTransactionByTxHash(ctx *gin.Context) {}

--- a/src/handler/model.go
+++ b/src/handler/model.go
@@ -22,6 +22,12 @@ type RespGetLatestBlocks struct {
 	RespStatus
 }
 
+type RespGetBlockDetail struct {
+	BlockInfo
+	Transactions []string `json:"transactions"`
+	RespStatus
+}
+
 // ==============================
 // Component model
 // ==============================


### PR DESCRIPTION
## Summary

fixed https://github.com/afunTW/eth-data-provider/issues/5

- Init endpoint `GET /blocks/:id`