### PR TITLE
feature: merge handler modeule into router

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/afunTW/eth-data-provider/src/config"
-	"github.com/afunTW/eth-data-provider/src/handler"
 	"github.com/afunTW/eth-data-provider/src/router"
 	"github.com/afunTW/eth-data-provider/src/service"
 	log "github.com/sirupsen/logrus"
@@ -20,7 +19,7 @@ func main() {
 	log.Info("Start service")
 	// run service in coroutine
 	config := config.NewConfig()
-	v1Handler := handler.NewHandlerV1Impl(config)
+	v1Handler := router.NewHandlerV1Impl(config)
 	router := router.NewRouter(v1Handler)
 	service := service.NewApiService(config, router)
 	go service.Run(ctx)

--- a/src/router/handler.go
+++ b/src/router/handler.go
@@ -1,4 +1,4 @@
-package handler
+package router
 
 import "github.com/gin-gonic/gin"
 

--- a/src/router/handler_v1_impl.go
+++ b/src/router/handler_v1_impl.go
@@ -1,4 +1,4 @@
-package handler
+package router
 
 import (
 	"fmt"

--- a/src/router/model.go
+++ b/src/router/model.go
@@ -1,4 +1,4 @@
-package handler
+package router
 
 // ==============================
 // Request model

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -2,14 +2,13 @@ package router
 
 import (
 	"github.com/afunTW/eth-data-provider/docs"
-	"github.com/afunTW/eth-data-provider/src/handler"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/swaggo/files"
 	"github.com/swaggo/gin-swagger"
 )
 
-func NewRouter(v1Handler handler.Handler) *gin.Engine {
+func NewRouter(v1Handler Handler) *gin.Engine {
 	router := gin.New()
 
 	// set customized router config


### PR DESCRIPTION
## Summary

Due to this repository is designed for multiple services and `handler` is too general purpose component naming. Integrate the `handler` to router since it's all for API routing